### PR TITLE
tooltip integration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: altair
-Version: 0.1.0
+Version: 0.0.6
 Title: R Interface to 'Altair'
 Description: Interface to 'Altair' <https://altair-viz.github.io>, which itself 
   is a Python interface to 'Vega-Lite' <https://vega.github.io/vega-lite>.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-# altair 0.1.0
+# altair 0.0.6
 
-* Update to use Altair 2.1.0
+* updates to use Altair 2.1.0, which offers tooltips (@aliciaschep)
 
 # altair 0.0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # altair 0.0.6
 
-* updates to use Altair 2.1.0, which offers tooltips (@aliciaschep)
+* updates to use Altair 2.1.0, which offers tooltips (#29, #46, @aliciaschep)
 
 # altair 0.0.5
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -99,6 +99,8 @@ Examples:
 
 - [First Example](https://vegawidget.github.io/altair/articles/first-example.html): a walkthrough to get a first chart to work
 
+- [Tooltips](https://vegawidget.github.io/altair/articles/tooltips.html): shows how Vega-Lite implements tooltips as an encoding within a chart, with formatting options
+
 - [Vega Datasets](https://vegawidget.github.io/altair/articles/vega-datasets.html): work with [Vega datasets](https://github.com/altair-viz/vega_datasets) using `import_vega_data()`
 
 - [View Composition](https://vegawidget.github.io/altair/articles/view-composition.html): how to facet, add layers to, repeat, and concatenate charts

--- a/README.md
+++ b/README.md
@@ -132,7 +132,12 @@ Examples:
 
   - [First
     Example](https://vegawidget.github.io/altair/articles/first-example.html):
-    a walkthrough to get a first chart to work
+    a walkthrough to get a first chart to
+    work
+
+  - [Tooltips](https://vegawidget.github.io/altair/articles/tooltips.html):
+    shows how Vega-Lite implements tooltips as an encoding within a
+    chart, with formatting options
 
   - [Vega
     Datasets](https://vegawidget.github.io/altair/articles/vega-datasets.html):

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -47,6 +47,7 @@ articles:
   - title: Getting started
     contents:
       - first-example
+      - tooltips
       - vega-datasets
       - view-composition
       - interactive

--- a/vignettes/first-example.Rmd
+++ b/vignettes/first-example.Rmd
@@ -29,7 +29,7 @@ chart <-
     x = "Horsepower:Q",
     y = "Miles_per_Gallon:Q",
     color = "Origin:N",
-    tooltip = c("Name","Horsepower", "Miles_per_Gallon", "Origin")
+    tooltip = c("Name", "Horsepower", "Miles_per_Gallon", "Origin")
   )
 
 vegawidget(chart)
@@ -121,7 +121,7 @@ chart <-
     x = "Horsepower:Q",
     y = "Miles_per_Gallon:Q",
     color = "Origin:N",
-    tooltip = c("Name","Horsepower", "Miles_per_Gallon", "Origin")
+    tooltip = c("Name", "Horsepower", "Miles_per_Gallon", "Origin")
   )
 ```
 
@@ -137,7 +137,13 @@ chart <-
     x = alt$X("Horsepower", type = "quantitative"),
     y = alt$Y("Miles_per_Gallon", type = "quantitative"),
     color = alt$Color("Origin", type = "nominal"),
-    tooltip = c("Name","Horsepower", "Miles_per_Gallon", "Origin")
+    tooltip = 
+      list(
+        alt$Tooltip(field = "Name", type = "nominal"),
+        alt$Tooltip(field = "Horsepower", type = "quantitative"),
+        alt$Tooltip(field = "Miles_per_Gallon", type = "quantitative"),
+        alt$Tooltip(field = "Origin", type = "nominal")
+      )
   )
 ```
 

--- a/vignettes/manifesto.Rmd
+++ b/vignettes/manifesto.Rmd
@@ -21,7 +21,6 @@ In the short term, the thought is to focus on a small number of items:
 
 1. Tightening up the existing capabilities.
 1. Will likely split the `vegawidget()` function, with its friends, into its own package. This would not introduce any API changes to this package.
-1. Tooltips.
 1. Some infrastructure to create and publish [blocks](https://bl.ocks.org/). ([#19](https://github.com/vegawidget/altair/issues/19))
 1. Consolidating datasets within a chart specification. ([#26](https://github.com/vegawidget/altair/issues/26))
 

--- a/vignettes/tooltips.Rmd
+++ b/vignettes/tooltips.Rmd
@@ -1,0 +1,98 @@
+---
+title: "Tooltips"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_document
+editor_options:
+  chunk_output_type: inline
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+In Vega-Lite, a tooltip is an encoding to which variables are attached.
+
+The Altair Python package offers us a shortcut to specify the tooltip encoding, by supplying the names of the variables we wish to appear in the tooltip. Altair and Vega-Lite apply some default behaviors.
+
+```{r base-chart}
+library("altair")
+
+vega_data <- import_vega_data()
+
+chart <- 
+  alt$Chart(r_to_py(vega_data$cars()))$
+  mark_point()$
+  encode(
+    x = "Horsepower:Q",
+    y = "Miles_per_Gallon:Q",
+    color = "Origin:N",
+    tooltip = c("Name", "Horsepower", "Miles_per_Gallon", "Origin")
+  )
+
+chart
+```
+
+You can use the `alt$Tooltip()` method to achieve the same outcome:
+
+```{r long}
+chart_new <- 
+  chart$
+  encode(
+    tooltip = 
+      list(
+        alt$Tooltip(field = "Name", type = "nominal"),
+        alt$Tooltip(field = "Horsepower", type = "quantitative"),
+        alt$Tooltip(field = "Miles_per_Gallon", type = "quantitative"),
+        alt$Tooltip(field = "Origin", type = "nominal")
+      )
+  )
+
+chart_new
+```
+
+Although it is more verbose than the shorthand form, it does allow you to be more expressive:
+
+```{r customize}
+chart_new <- 
+  chart$
+  encode(
+    tooltip = 
+      list(
+        alt$Tooltip(field = "Name", type = "nominal"),
+        alt$Tooltip(
+          field = "Year",
+          title = "Year",
+          type = "temporal", 
+          timeUnit = "year"
+        ),
+        alt$Tooltip(field = "Horsepower", type = "quantitative"),
+        alt$Tooltip(
+          field = "Miles_per_Gallon", 
+          format = ".2f",
+          title = "Gas Mileage (mpg)",
+          type = "quantitative"
+        ),
+        alt$Tooltip(field = "Origin", type = "nominal")
+      )
+  )
+
+chart_new
+```
+
+If there is no aggregation or time-unit specified, Vega-Lite will use the variable-name as the title for the field. Otherwise, Vega-Lite will modify the variable-name to indicate the time-unit or the aggregation. You can use the `title` option to override the default that Vega-Lite will propose.
+
+Also, you can specify the [format](https://vega.github.io/vega-lite/docs/format.html) of the values using the `format` option. For quantitative variables, [d3-format](https://github.com/d3/d3-format) is used; for temporal variables, [d3-time-format](https://github.com/d3/d3-time-format) is used.
+
+## Further reading
+
+- [Vega-Lite tooltips](https://vega.github.io/vega-lite/docs/tooltip.html)
+
+- [Vega-Lite format](https://vega.github.io/vega-lite/docs/format.html)
+
+- [D3 format](https://github.com/d3/d3-format)
+
+- [D3 time format](https://github.com/d3/d3-time-format)
+


### PR DESCRIPTION
Thanks for the PR! I'm still looking for a way to work collaboratively on a PR like this, so I hope this is OK.

It will be great to have tooltips again - and you were right (of course) that the end result would be both cleaner and more-robust!

For now, I'd like to keep our version numbers independent of "Altair", reserving the second digit to CRAN releases (another thing I need to get on). 

I think your proposal to put the tooltips in the "first example" is the right one. 

I have (somewhere) the tooltip article that got deleted when the "old" tooltips went away.

I can spend some time this morning to dig it up and modernize it. I will add it to this PR for your review.  